### PR TITLE
[Feat] #11 Add Header

### DIFF
--- a/project/src/App.js
+++ b/project/src/App.js
@@ -17,33 +17,47 @@ import MyChallengeDetailPage from "./pages/MyChallengeDetail";
 import ReviewPage from "./pages/Review";
 import NewReviewPage from "./pages/NewReview";
 import MemoPage from "./pages/Memo";
-
+import RootLayout from "./pages/Root";
 
 const router = createBrowserRouter([
-  {path: '/', element: <HomePage />, errorElement: <ErrorPage />, children: [
-    {path: 'search', element: <SearchPage />},
-    {path: 'search/result', element: <SearchResultPage />},
-    {path: 'challenge', element: <ChallengePage /> },
-    {path: 'auth', element: <AuthenticationPage /> },
-    {path: 'auth/findpw', element: <FindPwPage /> },
-    {path: 'mypage', element: <MyPage />, children: [
-      {path: 'account', element: <AccountPage />},
-      {path: 'recent', element: <RecentReadsPage />},
-      {path: 'tobe', element: <ToBeReadsPage />},
-      {path: 'mychallenge', element: <ChallengeRoot />, children: [
-        {index: true, element: <MyChallengePage />},
-        {path: 'new', element: <NewChallengePage />},
-        {path: ':challengeId', element: <MyChallengeDetailPage />}
-      ]},
-      {path: 'review', element: <ReviewPage />},
-      {path: 'review/new', element: <NewReviewPage />},
-      {path: 'memo', element: <MemoPage />}
-    ]}
-  ]}
+  {
+    path: "/",
+    element: <RootLayout />,
+    errorElement: <ErrorPage />,
+    children: [
+      { index: true, element: <HomePage /> },
+      { path: "search", element: <SearchPage /> },
+      { path: "search/result", element: <SearchResultPage /> },
+      { path: "challenge", element: <ChallengePage /> },
+      { path: "auth", element: <AuthenticationPage /> },
+      { path: "auth/findpw", element: <FindPwPage /> },
+      {
+        path: "mypage",
+        element: <MyPage />,
+        children: [
+          { path: "account", element: <AccountPage /> },
+          { path: "recent", element: <RecentReadsPage /> },
+          { path: "tobe", element: <ToBeReadsPage /> },
+          {
+            path: "mychallenge",
+            element: <ChallengeRoot />,
+            children: [
+              { index: true, element: <MyChallengePage /> },
+              { path: "new", element: <NewChallengePage /> },
+              { path: ":challengeId", element: <MyChallengeDetailPage /> },
+            ],
+          },
+          { path: "review", element: <ReviewPage /> },
+          { path: "review/new", element: <NewReviewPage /> },
+          { path: "memo", element: <MemoPage /> },
+        ],
+      },
+    ],
+  },
 ]);
 
 function App() {
-  return <RouterProvider router={router} />
+  return <RouterProvider router={router} />;
 }
 
 export default App;

--- a/project/src/components/MainNavigation.js
+++ b/project/src/components/MainNavigation.js
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { NavLink, Link } from "react-router-dom";
+
+import "./Root.css";
+
+const MainNavigation = () => {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  return (
+    <header>
+      <div className="tnb">
+        <ul>
+          {!isLoggedIn ? (
+            <>
+              <li>
+                <NavLink to="auth">로그인</NavLink>
+              </li>
+              <li>
+                <NavLink to="auth">회원가입</NavLink>
+              </li>
+            </>
+          ) : (
+            <li>
+              <NavLink to="mypage">마이페이지</NavLink>
+            </li>
+          )}
+        </ul>
+      </div>
+      <div className="gnb">
+        <h1>
+          <Link to="">로고</Link>
+        </h1>
+        <nav>
+          <ul>
+            <li>
+              <NavLink to="" end>
+                Home
+              </NavLink>
+            </li>
+            <li>
+              <NavLink to="search">Search</NavLink>
+            </li>
+            <li>
+              <NavLink to="challenge">Challenge</NavLink>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+  );
+};
+
+export default MainNavigation;

--- a/project/src/components/Root.css
+++ b/project/src/components/Root.css
@@ -1,0 +1,31 @@
+* {
+  margin: 0;
+  padding: 0;
+}
+a {
+  text-decoration: none;
+}
+ul {
+  list-style: none;
+}
+header {
+  margin: 10px 20px;
+}
+.tnb > ul {
+  display: flex;
+  justify-content: flex-end;
+}
+.tnb > ul > li {
+  margin-right: 10px;
+}
+.gnb {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+nav > ul {
+  display: flex;
+}
+nav > ul > li {
+  margin-right: 10px;
+}

--- a/project/src/pages/Authentication.js
+++ b/project/src/pages/Authentication.js
@@ -1,0 +1,5 @@
+const AuthenticationPage = () => {
+  return <div>인증 페이지</div>;
+};
+
+export default AuthenticationPage;

--- a/project/src/pages/Challenge.js
+++ b/project/src/pages/Challenge.js
@@ -1,0 +1,5 @@
+const ChallengePage = () => {
+  return <div>전체 챌린지 페이지</div>;
+};
+
+export default ChallengePage;

--- a/project/src/pages/Error.js
+++ b/project/src/pages/Error.js
@@ -1,0 +1,5 @@
+const ErrorPage = () => {
+  return <div>에러 페이지</div>;
+};
+
+export default ErrorPage;

--- a/project/src/pages/FindPw.js
+++ b/project/src/pages/FindPw.js
@@ -1,0 +1,5 @@
+const FindPwPage = () => {
+  return <div>비밀번호 찾기 페이지</div>;
+};
+
+export default FindPwPage;

--- a/project/src/pages/Memo.js
+++ b/project/src/pages/Memo.js
@@ -1,0 +1,5 @@
+const MemoPage = () => {
+  return <div>메모 페이지</div>;
+};
+
+export default MemoPage;

--- a/project/src/pages/MyChallenge.js
+++ b/project/src/pages/MyChallenge.js
@@ -1,0 +1,5 @@
+const MyChallengePage = () => {
+  return <div>마이 챌린지 페이지</div>;
+};
+
+export default MyChallengePage;

--- a/project/src/pages/MyChallengeDetail.js
+++ b/project/src/pages/MyChallengeDetail.js
@@ -1,0 +1,5 @@
+const MyChallengeDetailPage = () => {
+  return <div>챌린지 상세 페이지</div>;
+};
+
+export default MyChallengeDetailPage;

--- a/project/src/pages/MyChallengeRoot.js
+++ b/project/src/pages/MyChallengeRoot.js
@@ -1,0 +1,5 @@
+const ChallengeRoot = () => {
+  return <div>챌린지 루트 페이지</div>;
+};
+
+export default ChallengeRoot;

--- a/project/src/pages/NewChallenge.js
+++ b/project/src/pages/NewChallenge.js
@@ -1,0 +1,5 @@
+const NewChallengePage = () => {
+  return <div>챌린지 등록 페이지</div>;
+};
+
+export default NewChallengePage;

--- a/project/src/pages/NewReview.js
+++ b/project/src/pages/NewReview.js
@@ -1,0 +1,5 @@
+const NewReviewPage = () => {
+  return <div>독후감 등록 페이지</div>;
+};
+
+export default NewReviewPage;

--- a/project/src/pages/RecentReads.js
+++ b/project/src/pages/RecentReads.js
@@ -1,0 +1,5 @@
+const RecentReadsPage = () => {
+  return <div>읽은 책 리스트 페이지</div>;
+};
+
+export default RecentReadsPage;

--- a/project/src/pages/Review.js
+++ b/project/src/pages/Review.js
@@ -1,0 +1,5 @@
+const ReviewPage = () => {
+  return <div>독후감 페이지</div>;
+};
+
+export default ReviewPage;

--- a/project/src/pages/Root.js
+++ b/project/src/pages/Root.js
@@ -1,0 +1,15 @@
+import { Outlet } from "react-router-dom";
+import MainNavigation from "../components/MainNavigation";
+
+const RootLayout = () => {
+  return (
+    <>
+      <MainNavigation />
+      <main>
+        <Outlet />
+      </main>
+    </>
+  );
+};
+
+export default RootLayout;

--- a/project/src/pages/Search.js
+++ b/project/src/pages/Search.js
@@ -1,0 +1,5 @@
+const SearchPage = () => {
+  return <div>검색 페이지</div>;
+};
+
+export default SearchPage;

--- a/project/src/pages/SearchResult.js
+++ b/project/src/pages/SearchResult.js
@@ -1,0 +1,5 @@
+const SearchResultPage = () => {
+  return <div>검색 결과 페이지</div>;
+};
+
+export default SearchResultPage;

--- a/project/src/pages/ToBeReads.js
+++ b/project/src/pages/ToBeReads.js
@@ -1,0 +1,5 @@
+const ToBeReadsPage = () => {
+  return <div>읽을 책 리스트 페이지</div>;
+};
+
+export default ToBeReadsPage;


### PR DESCRIPTION
header를 크게 tnb와 gnb로 나누어 tnb에 로그인, 회원가입/마이페이지 gnb에 로고와 메인내비게이션을 담았음.

추가 수정 사항
1. RootLayout을 만들고 공통 컴포넌트인 header와 Outlet으로 동작하게 함, HomePage는 children index:true로 내려줌
2. 각 페이지들이 빈 페이지라 기본 경로에서는 확인할 수 없는 오류가 떠서 긴급하게 rafce 작성해줌.

주의사항
1. 일단 기본 css로 스타일링 하였으나 추후 tailwind로 수정할 예정